### PR TITLE
Allowing transparent background for charts

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -137,6 +137,7 @@ SmoothieChart.prototype.render = function(canvas, time) {
   // Clear the working area.
   canvasContext.save();
   canvasContext.fillStyle = options.grid.fillStyle;
+  canvasContext.clearRect(0, 0, dimensions.width, dimensions.height);
   canvasContext.fillRect(0, 0, dimensions.width, dimensions.height);
   canvasContext.restore();
 


### PR DESCRIPTION
In my project I need charts to have transparent background (to place them over background images)
I noticed that simple setting `grid.fillStyle` option to `rgba(0,0,0,0)` does not work properly, so I've added this tiny little fix which allows transparent background.
