### PR TITLE
Synchronized auto-scaling with multiple charts

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -44,6 +44,7 @@ function TimeSeries(options) {
   options.resetBounds = options.resetBounds || true; // Enable or disable the resetBounds timer
   this.options = options;
   this.data = [];
+  this.referenceSeries = options.referenceSeries || this; 
   
   this.maxValue = Number.NaN; // The maximum value ever seen in this time series.
   this.minValue = Number.NaN; // The minimum value ever seen in this time series.
@@ -56,6 +57,11 @@ function TimeSeries(options) {
 
 // Reset the min and max for this timeseries so the graph rescales itself
 TimeSeries.prototype.resetBounds = function() {
+  if (this.referenceSeries !== this)  {
+     this.maxValue = this.referenceSeries.maxValue;
+     this.minValue = this.referenceSeries.minValue;
+     return
+  }
   this.maxValue = Number.NaN;
   this.minValue = Number.NaN;
   for (var i = 0; i < this.data.length; i++) {


### PR DESCRIPTION
You can pass "referenceSeries" as an option to a chart which causes this
chart to use the referenced time series as the basis for its
auto-scaling.
