### PR TITLE
re-add parseFloat to default y-axis formatters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothie",
-  "version": "1.23.0",
+  "version": "1.24.0",
   "description": "Smoothie Charts: smooooooth JavaScript charts for realtime streaming data",
   "main": "./smoothie.js",
   "directories": {

--- a/smoothie.js
+++ b/smoothie.js
@@ -66,6 +66,7 @@
  * v1.21: Add 'step' interpolation mode, by @drewnoakes
  * v1.22: Add support for different pixel ratios. Also add optional y limit formatters, by @copacetic
  * v1.23: Fix bug introduced in v1.22 (#44), by @drewnoakes
+ * v1.24: Fix bug introduced in v1.23, re-adding parseFloat to y-axis formatter defaults, by @siggy_sf
  */
 
 ;(function(exports) {
@@ -214,10 +215,10 @@
    *   millisPerPixel: 20,                       // sets the speed at which the chart pans by
    *   enableDpiScaling: true,                   // support rendering at different DPI depending on the device
    *   yMinFormatter: function(min, precision) { // callback function that formats the min y value label
-   *     return min.toFixed(precision);
+   *     return parseFloat(min).toFixed(precision);
    *   },
    *   yMaxFormatter: function(max, precision) { // callback function that formats the max y value label
-   *     return max.toFixed(precision);
+   *     return parseFloat(max).toFixed(precision);
    *   },
    *   maxDataSetLength: 2,
    *   interpolation: 'bezier'                   // one of 'bezier', 'linear', or 'step'
@@ -258,8 +259,12 @@
   SmoothieChart.defaultChartOptions = {
     millisPerPixel: 20,
     enableDpiScaling: true,
-    yMinFormatter: function(min, precision) { return min.toFixed(precision); },
-    yMaxFormatter: function(max, precision) { return max.toFixed(precision); },
+    yMinFormatter: function(min, precision) {
+      return parseFloat(min).toFixed(precision);
+    },
+    yMaxFormatter: function(max, precision) {
+      return parseFloat(max).toFixed(precision);
+    },
     maxValueScale: 1,
     interpolation: 'bezier',
     scaleSmoothing: 0.125,


### PR DESCRIPTION
Upgraded from 1.18 to 1.23, starting seeing undefined errors in yMinFormatter:
https://github.com/joewalnes/smoothie/blob/master/smoothie.js#L261

Noticed calls to parseFloat were removed in commit fe2d5f99bb4bcbbc877687436a0c86c3ca466a05, prior to 1.23 release.

Looks like this issue was already reported: https://github.com/joewalnes/smoothie/issues/35
