### PR TITLE
Fixed bug with inserting the oldest item into a TimeSeries

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -168,7 +168,7 @@
     if (i === -1) {
       // This new item is the oldest data
       this.data.splice(0, 0, [timestamp, value]);
-    else if (this.data.length > 0 && this.data[i][0] === timestamp) {
+    } else if (this.data.length > 0 && this.data[i][0] === timestamp) {
       // Update existing values in the array
       if (sumRepeatedTimeStampValues) {
         // Sum this value into the existing 'bucket'


### PR DESCRIPTION
There's an issue where an item is not correctly inserted into a TimeSeries when it is the oldest item. Here's a code snippet that can reproduce the bug:

``` html
<!DOCTYPE html>
<html xmlns="http://www.w3.org/1999/xhtml">
    <head>
        <title>Smoothie Tests</title>
        <script type="text/javascript" src="smoothie.js"></script>
        <script type="text/javascript" src="http://code.jquery.com/jquery-2.1.1.min.js"></script>
        <script type="text/javascript">
        $(document).ready(function() {
            var ts = new TimeSeries();
            var canvas = $('#chart1')[0];
            var chart = new SmoothieChart();
            chart.addTimeSeries(ts);
            chart.streamTo(canvas);
            var now = new Date().getTime();
            ts.append(now, 100);
            ts.append(now - 1000, 200); 
            ts.append(now - 1500, 250); 
            ts.append(now + 1000, 150); 
        });
        </script>
    </head>
    <body>
        <canvas id="chart1" width="500" height="100"></canvas>
    </body>
</html>
```

You should notice the chart is drawn backwards then forwards. This happens because the TimeSeries is out of order.
