### PR TITLE
Unify [max|min]ValueScale and consider range as the base

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -497,11 +497,11 @@
       for (var d = 0; d < this.seriesSet.length; d++) {
         // TODO(ndunn): We could calculate / track these values as they stream in.
         var timeSeries = this.seriesSet[d].timeSeries;
-        if (!isNaN(timeSeries.maxValue)) {
+        if (chartOptions.maxValue == null && !isNaN(timeSeries.maxValue)) {
           chartMaxValue = chartMaxValue > timeSeries.maxValue ? chartMaxValue : timeSeries.maxValue;
         }
 
-        if (!isNaN(timeSeries.minValue)) {
+        if (chartOptions.minValue == null && !isNaN(timeSeries.minValue)) {
           chartMinValue = chartMinValue > timeSeries.minValue ? chartMinValue : timeSeries.minValue;
         }
       }


### PR DESCRIPTION
Unifies the handling of `max` and `min` scalars by simply using them relative to the value range

Also shortcuts the loop if `max` and `min` are already known
