### PR TITLE
Add types to package.json and fix bug in smoothie.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.29.0",
   "description": "Smoothie Charts: smooooooth JavaScript charts for realtime streaming data",
   "main": "./smoothie.js",
+  "types": "./smoothie.d.ts",
   "directories": {
     "doc": "docs",
     "example": "examples",

--- a/smoothie.d.ts
+++ b/smoothie.d.ts
@@ -129,8 +129,8 @@ export interface IChartOptions {
 
     labels?: ILabelOptions;
 
-    /** Allows the chart to stretch according to its containers and layout settings. Default is <code>false</code>, for backwards compatibility.
-    responsive: boolean;
+    /** Allows the chart to stretch according to its containers and layout settings. Default is <code>false</code>, for backwards compatibility. */
+    responsive?: boolean;
 }
 
 /**


### PR DESCRIPTION
Add types to the package.json file so they can be found when importing it as a module.
Also there was a missing closing comment in the typescript file which prevented it from working.