### PR TITLE
Target FPS/Refresh Rate

### DIFF
--- a/smoothie.d.ts
+++ b/smoothie.d.ts
@@ -132,7 +132,7 @@ export interface IChartOptions {
     /** Allows the chart to stretch according to its containers and layout settings. Default is <code>false</code>, for backwards compatibility. */
     responsive?: boolean;
 
-    /** Sets the target refrsh rate in milliseconds. FPS = 1000/rate */
+    /** Sets the target refresh rate in milliseconds. FPS = 1000/rate */
     targetRefreshRate?: number;
 }
 

--- a/smoothie.d.ts
+++ b/smoothie.d.ts
@@ -131,6 +131,9 @@ export interface IChartOptions {
 
     /** Allows the chart to stretch according to its containers and layout settings. Default is <code>false</code>, for backwards compatibility. */
     responsive?: boolean;
+
+    /** Sets the target refrsh rate in milliseconds. FPS = 1000/rate */
+    targetRefreshRate?: number;
 }
 
 /**
@@ -194,4 +197,10 @@ export declare class SmoothieChart {
     render(canvas?: HTMLCanvasElement, time?: number): void;
 
     static timeFormatter(date: Date): string;
+
+    /**
+     * Sets the target FPS
+     * @param fps the desired FPS
+     */
+    setTargetFPS(fps: number): void;
 }

--- a/smoothie.js
+++ b/smoothie.js
@@ -308,7 +308,8 @@
       precision: 2
     },
     horizontalLines: [],
-    responsive: false
+    responsive: false,
+    targetRefreshRate: 16
   };
 
   // Based on http://inspirit.github.com/jsfeat/js/compatibility.js
@@ -436,6 +437,14 @@
   };
 
   /**
+   * Sets the target FPS
+   * @param fps the desired FPS
+   */
+  SmoothieChart.prototype.setTargetFPS = function(fps) {
+    this.options.targetRefreshRate = 1000 / fps;
+  }
+
+  /**
    * Make sure the canvas has the optimal resolution for the device's pixel ratio.
    */
   SmoothieChart.prototype.resize = function () {
@@ -560,6 +569,8 @@
 
   SmoothieChart.prototype.render = function(canvas, time) {
     var nowMillis = new Date().getTime();
+    //Do we want to render?
+    if (nowMillis - this.lastRenderTimeMillis < this.options.targetRefreshRate) return;
 
     if (!this.isAnimatingScale) {
       // We're not animating. We can use the last render time and the scroll speed to work out whether


### PR DESCRIPTION
For a project that Im working on the Raspberry I needed Smoothie to take less render time, so another WebGL canvas could get more FPS.

I made these changes so now I can find a balance between smoothness and performance.
```
this.chart = new Smooth.SmoothieChart({responsive: true, scaleSmoothing: 0.7});
this.chart.setTargetFPS(24);
```
It may be useful to someone else.