### PR TITLE
Fix inverted logic in devicePixelRatio test

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -439,7 +439,7 @@
    * Make sure the canvas has the optimal resolution for the device's pixel ratio.
    */
   SmoothieChart.prototype.resize = function () {
-    var dpr = !this.options.enableDpiScaling || !window ? window.devicePixelRatio : 1,
+    var dpr = !this.options.enableDpiScaling || !window ? 1 : window.devicePixelRatio,
         width, height;
     if (this.options.responsive) {
       // Newer behaviour: Use the canvas's size in the layout, and set the internal


### PR DESCRIPTION
The condition in the ternary operator is true if there's any
reason NOT to use the window.devicePixelRatio. Put the default
in the 'true' arm, and devicePixelRatio in the 'false' condition
where it's useful.

Tested on iOS with Safari's remote debugger, verified that dpr==2.