### PR TITLE
Fixed a bug in "series fill" when using "scroll backwards"

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -950,9 +950,15 @@
       if (dataSet.length > 1) {
         if (seriesOptions.fillStyle) {
           // Close up the fill region.
-          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, lastY);
-          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, dimensions.height + seriesOptions.lineWidth + 1);
-          context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
+          if (chartOptions.scrollBackwards) {
+            context.lineTo(lastX, dimensions.height + seriesOptions.lineWidth);
+            context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
+            context.lineTo(firstX, firstY);
+          } else {
+            context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, lastY);
+            context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, dimensions.height + seriesOptions.lineWidth + 1);
+            context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
+          }
           context.fillStyle = seriesOptions.fillStyle;
           context.fill();
         }
@@ -1055,5 +1061,4 @@
   exports.SmoothieChart = SmoothieChart;
 
 })(typeof exports === 'undefined' ? this : exports);
-
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -899,13 +899,14 @@
       // Draw the line...
       context.beginPath();
       // Retain lastX, lastY for calculating the control points of bezier curves.
-      var firstX = 0, lastX = 0, lastY = 0;
+      var firstX = 0, firstY = 0, lastX = 0, lastY = 0;
       for (var i = 0; i < dataSet.length && dataSet.length !== 1; i++) {
         var x = timeToXPixel(dataSet[i][0]),
             y = valueToYPixel(dataSet[i][1]);
 
         if (i === 0) {
           firstX = x;
+          firstY = y;
           context.moveTo(x, y);
         } else {
           switch (chartOptions.interpolation) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -91,6 +91,7 @@
  * v1.36: Add tooltipLabel to ITimeSeriesPresentationOptions.
  *        If tooltipLabel is present, tooltipLabel displays inside tooltip
  *        next to value, by @jackdesert (#102)
+ *        Fix bug rendering issue in series fill when using scroll backwards, by @olssonfredrik
  */
 
 ;(function(exports) {


### PR DESCRIPTION
Open the builder and enable _Scroll Backwards_ and _Series fill_ and notice that the fill doesn't render as intended. This pull fixes that bug.