### PR TITLE
to avoid unnecessary divs in the dom

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -552,6 +552,9 @@
   };
 
   SmoothieChart.prototype.updateTooltip = function () {
+    if(!this.options.tooltip){
+     return; 
+    }
     var el = this.getTooltipEl();
 
     if (!this.mouseover || !this.options.tooltip) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -599,7 +599,9 @@
     this.mouseY = evt.offsetY;
     this.mousePageX = evt.pageX;
     this.mousePageY = evt.pageY;
-
+    if(!this.options.tooltip){
+     return; 
+    }
     var el = this.getTooltipEl();
     el.style.top = Math.round(this.mousePageY) + 'px';
     el.style.left = Math.round(this.mousePageX) + 'px';


### PR DESCRIPTION
I am working with smoothie and everything goes well,  the thing is I am using more than 10 charts at the same time, and some dynamic ones, and my DOM is getting bigger and bigger with this  "smoothie-chart-tooltip" div, even if I am not using tooltip, I just added a little validation and is working.