### PR TITLE
Filter NaN

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -208,6 +208,10 @@
    * whether it is replaced, or the values summed (defaults to false.)
    */
   TimeSeries.prototype.append = function(timestamp, value, sumRepeatedTimeStampValues) {
+	// Reject NaN
+	if (isNaN(timestamp) || isNaN(value)){
+		return
+	}  
     // Rewind until we hit an older timestamp
     var i = this.data.length - 1;
     while (i >= 0 && this.data[i][0] > timestamp) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -93,6 +93,7 @@
  *        next to value, by @jackdesert (#102)
  *        Fix bug rendering issue in series fill when using scroll backwards, by @olssonfredrik
  *        Add title option, by @mesca
+ *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  */
 
 ;(function(exports) {


### PR DESCRIPTION
Re #114, ```append()``` has been modified so that it rejects a point when the time or value is NaN. Previously, points containing NaN could be added, which did not seem to affect operation visibly, but did cause the timeseries to grow without bound when a time of NaN was added. This mod has been tested by forcing append(NaN,<value>), append(<time>,NaN) and append(NaN,NaN) for every genuine data point I add to a timeseries, then checking they no longer appear in the timeseries array. 