### PR TITLE
chore: add GitHub action to auto-publish to NPM

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,19 @@
+name: Publish to NPM
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    paths:
+      - package.json # If this didn't change, the package version didn't change.
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Runs on pushes to `master` branch that involve changes to `package.json` (such as version bump).

For this to start working, a collaborator needs to create an npm token (`npm token create`) and add it to repository's settings -> secrets under name `npm_token`.

I've tested it on my fork package.

Related to #124.