### PR TITLE
chore: bump version to 1.36.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothie",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "description": "Smoothie Charts: smooooooth JavaScript charts for realtime streaming data",
   "main": "./smoothie.js",
   "types": "./smoothie.d.ts",

--- a/smoothie.d.ts
+++ b/smoothie.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for Smoothie Charts 1.35
+// Type definitions for Smoothie Charts 1.36
 // Project: https://github.com/joewalnes/smoothie
 // Definitions by: Drew Noakes <https://drewnoakes.com>
 //                 Mike H. Hawley <https://github.com/mikehhawley>


### PR DESCRIPTION
It's better to merge it after #127, therefore WIP.
Related (or closes, if everything goes right): #124.