### PR TITLE
perf: remove an unnecessary call to `updateTooltip`

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -798,7 +798,6 @@
     }
 
     this.resize();
-    this.updateTooltip();
 
     this.lastRenderTimeMillis = nowMillis;
 
@@ -1011,8 +1010,8 @@
       context.lineTo(this.mouseX, dimensions.height);
       context.closePath();
       context.stroke();
-      this.updateTooltip();
     }
+    this.updateTooltip();
 
     // Draw the axis values on the chart.
     if (!chartOptions.labels.disabled && !isNaN(this.valueRange.min) && !isNaN(this.valueRange.max)) {


### PR DESCRIPTION
Leaving the bottom one because `updateTooltip` depends on `lastChartTimestamp`, it needs to get updated before `updateTooltip` call.