### PR TITLE
fix: make all lines sharp

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -96,7 +96,7 @@
  *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  *        Allow setting interpolation per time series, by @WofWca (#123)
  *        Fix chart constantly jumping in 1-2 pixel steps, by @WofWca (#131)
- *        Fix: make all lines sharp, by @WofWca (#134)
+ *        Fix: make all lines sharp, remove the `grid.sharpLines` option by @WofWca (#134)
  */
 
 ;(function(exports) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/39462442/134342530-d23c4540-24f0-4345-8157-8c832146c231.png)

After:
![image](https://user-images.githubusercontent.com/39462442/134342663-56e899ca-5728-43a9-9d42-3cc357ba674c.png)

Closes #57.
This removes the `grid.sharpLines` option.

Base branch is #131, so TODO:
* [ ] Merge #131.