### PR TITLE
fix: `this.delay` not being respected with `nonRealtimeData: true`

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -95,6 +95,7 @@
  *        Add title option, by @mesca
  *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  *        Allow setting interpolation per time series, by @WofWca (#123)
+ *        Fix chart constantly jumping in 1-2 pixel steps, by @WofWca (#131)
  */
 
 ;(function(exports) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -96,6 +96,7 @@
  *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  *        Allow setting interpolation per time series, by @WofWca (#123)
  *        Fix chart constantly jumping in 1-2 pixel steps, by @WofWca (#131)
+ *        Fix `this.delay` not being respected with `nonRealtimeData: true`, by @WofWca (#137)
  */
 
 ;(function(exports) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -784,31 +784,31 @@
     if (this.options.limitFPS > 0 && nowMillis - this.lastRenderTimeMillis < (1000/this.options.limitFPS))
       return;
 
-    if (!this.isAnimatingScale) {
-      // We're not animating. We can use the last render time and the scroll speed to work out whether
-      // we actually need to paint anything yet. If not, we can return immediately.
-
-      // Render at least every 1/6th of a second. The canvas may be resized, which there is
-      // no reliable way to detect.
-      var maxIdleMillis = Math.min(1000/6, this.options.millisPerPixel);
-
-      if (nowMillis - this.lastRenderTimeMillis < maxIdleMillis) {
-        return;
-      }
-    }
-
-    this.resize();
-
-    this.lastRenderTimeMillis = nowMillis;
-
-    canvas = canvas || this.canvas;
     time = time || nowMillis - (this.delay || 0);
 
     // Round time down to pixel granularity, so motion appears smoother.
     time -= time % this.options.millisPerPixel;
 
+    if (!this.isAnimatingScale) {
+      // We're not animating. We can use the last render time and the scroll speed to work out whether
+      // we actually need to paint anything yet. If not, we can return immediately.
+      var sameTime = this.lastChartTimestamp === time;
+      if (sameTime) {
+        // Render at least every 1/6th of a second. The canvas may be resized, which there is
+        // no reliable way to detect.
+        var needToRenderInCaseCanvasResized = nowMillis - this.lastRenderTimeMillis > 1000/6;
+        if (!needToRenderInCaseCanvasResized) {
+          return;
+        }
+      }
+    }
+
+    this.lastRenderTimeMillis = nowMillis;
     this.lastChartTimestamp = time;
 
+    this.resize();
+
+    canvas = canvas || this.canvas;
     var context = canvas.getContext('2d'),
         chartOptions = this.options,
         dimensions = { top: 0, left: 0, width: canvas.clientWidth, height: canvas.clientHeight },

--- a/smoothie.js
+++ b/smoothie.js
@@ -785,7 +785,7 @@
     if (this.options.limitFPS > 0 && nowMillis - this.lastRenderTimeMillis < (1000/this.options.limitFPS))
       return;
 
-    time = time || nowMillis - (this.delay || 0);
+    time = (time || nowMillis) - (this.delay || 0);
 
     // Round time down to pixel granularity, so motion appears smoother.
     time -= time % this.options.millisPerPixel;


### PR DESCRIPTION
and when the user calls `render` manually with a custom `time` argument

TODO:

* [ ] Merge #131 as this is based on that.
* [ ] Think about whether the change is actually for the better - maybe it's more intuitive that if you use `nonRealtimeData` that there is no delay, and if you're manually calling `render()` with custom time that you've also factored the delay you want into the `time` argument.