### PR TITLE
fix: series fill & stroke being inconsistent for last data time < render time

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -911,17 +911,17 @@
 
     // For each data set...
     for (var d = 0; d < this.seriesSet.length; d++) {
-      var timeSeries = this.seriesSet[d].timeSeries;
+      var timeSeries = this.seriesSet[d].timeSeries,
+          dataSet = timeSeries.data;
 
       // Delete old data that's moved off the left of the chart.
       timeSeries.dropOldData(oldestValidTime, chartOptions.maxDataSetLength);
-      if (timeSeries.disabled) {
+      if (dataSet.length <= 1 || timeSeries.disabled) {
           continue;
       }
       context.save();
 
-      var dataSet = timeSeries.data,
-          seriesOptions = this.seriesSet[d].options;
+      var seriesOptions = this.seriesSet[d].options;
 
       // Set style for this dataSet.
       context.lineWidth = seriesOptions.lineWidth;
@@ -930,7 +930,7 @@
       context.beginPath();
       // Retain lastX, lastY for calculating the control points of bezier curves.
       var firstX = 0, firstY = 0, lastX = 0, lastY = 0;
-      for (var i = 0; i < dataSet.length && dataSet.length !== 1; i++) {
+      for (var i = 0; i < dataSet.length; i++) {
         var x = timeToXPixel(dataSet[i][0]),
             y = valueToYPixel(dataSet[i][1]);
 
@@ -978,27 +978,26 @@
         lastX = x; lastY = y;
       }
 
-      if (dataSet.length > 1) {
-        if (seriesOptions.fillStyle) {
-          // Close up the fill region.
-          if (chartOptions.scrollBackwards) {
-            context.lineTo(lastX, dimensions.height + seriesOptions.lineWidth);
-            context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
-            context.lineTo(firstX, firstY);
-          } else {
-            context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, lastY);
-            context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, dimensions.height + seriesOptions.lineWidth + 1);
-            context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
-          }
-          context.fillStyle = seriesOptions.fillStyle;
-          context.fill();
+      if (seriesOptions.fillStyle) {
+        // Close up the fill region.
+        if (chartOptions.scrollBackwards) {
+          context.lineTo(lastX, dimensions.height + seriesOptions.lineWidth);
+          context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
+          context.lineTo(firstX, firstY);
+        } else {
+          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, lastY);
+          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, dimensions.height + seriesOptions.lineWidth + 1);
+          context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
         }
-
-        if (seriesOptions.strokeStyle && seriesOptions.strokeStyle !== 'none') {
-          context.stroke();
-        }
-        context.closePath();
+        context.fillStyle = seriesOptions.fillStyle;
+        context.fill();
       }
+
+      if (seriesOptions.strokeStyle && seriesOptions.strokeStyle !== 'none') {
+        context.stroke();
+      }
+      context.closePath();
+
       context.restore();
     }
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -946,48 +946,55 @@
       var firstX = timeToXPixel(dataSet[0][0]),
         firstY = valueToYPixel(dataSet[0][1]),
         lastX = firstX,
-        lastY = firstY;
+        lastY = firstY,
+        draw;
       context.moveTo(firstX, firstY);
-      for (var i = 1; i < dataSet.length; i++) {
-        var iThData = dataSet[i],
-            x = timeToXPixel(iThData[0]),
-            y = valueToYPixel(iThData[1]);
-
-        switch (seriesOptions.interpolation || chartOptions.interpolation) {
-          case "linear":
-          case "line": {
+      switch (seriesOptions.interpolation || chartOptions.interpolation) {
+        case "linear":
+        case "line": {
+          draw = function(x, y, lastX, lastY) {
             context.lineTo(x,y);
-            break;
           }
-          case "bezier":
-          default: {
-            // Great explanation of Bezier curves: http://en.wikipedia.org/wiki/Bezier_curve#Quadratic_curves
-            //
-            // Assuming A was the last point in the line plotted and B is the new point,
-            // we draw a curve with control points P and Q as below.
-            //
-            // A---P
-            //     |
-            //     |
-            //     |
-            //     Q---B
-            //
-            // Importantly, A and P are at the same y coordinate, as are B and Q. This is
-            // so adjacent curves appear to flow as one.
-            //
+          break;
+        }
+        case "bezier":
+        default: {
+          // Great explanation of Bezier curves: http://en.wikipedia.org/wiki/Bezier_curve#Quadratic_curves
+          //
+          // Assuming A was the last point in the line plotted and B is the new point,
+          // we draw a curve with control points P and Q as below.
+          //
+          // A---P
+          //     |
+          //     |
+          //     |
+          //     Q---B
+          //
+          // Importantly, A and P are at the same y coordinate, as are B and Q. This is
+          // so adjacent curves appear to flow as one.
+          //
+          draw = function(x, y, lastX, lastY) {
             context.bezierCurveTo( // startPoint (A) is implicit from last iteration of loop
               Math.round((lastX + x) / 2), lastY, // controlPoint1 (P)
               Math.round((lastX + x)) / 2, y, // controlPoint2 (Q)
               x, y); // endPoint (B)
-            break;
           }
-          case "step": {
+          break;
+        }
+        case "step": {
+          draw = function(x, y, lastX, lastY) {
             context.lineTo(x,lastY);
             context.lineTo(x,y);
-            break;
           }
+          break;
         }
+      }
 
+      for (var i = 1; i < dataSet.length; i++) {
+        var iThData = dataSet[i],
+            x = timeToXPixel(iThData[0]),
+            y = valueToYPixel(iThData[1]);
+        draw(x, y, lastX, lastY);
         lastX = x; lastY = y;
       }
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -947,8 +947,9 @@
         lastY = firstY;
       context.moveTo(firstX, firstY);
       for (var i = 1; i < dataSet.length; i++) {
-        var x = timeToXPixel(dataSet[i][0]),
-            y = valueToYPixel(dataSet[i][1]);
+        var iThData = dataSet[i],
+            x = timeToXPixel(iThData[0]),
+            y = valueToYPixel(iThData[1]);
 
         switch (seriesOptions.interpolation || chartOptions.interpolation) {
           case "linear":

--- a/smoothie.js
+++ b/smoothie.js
@@ -592,7 +592,7 @@
     // x pixel to time
     var t = this.options.scrollBackwards
       ? time - this.mouseX * this.options.millisPerPixel
-      : time - (this.canvas.offsetWidth - this.mouseX) * this.options.millisPerPixel;
+      : time - (this.clientWidth - this.mouseX) * this.options.millisPerPixel;
 
     var data = [];
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -999,25 +999,19 @@
         lastX = x; lastY = y;
       }
 
-      if (seriesOptions.fillStyle) {
-        // Close up the fill region.
-        if (chartOptions.scrollBackwards) {
-          context.lineTo(lastX, dimensions.height + seriesOptions.lineWidth);
-          context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
-          context.lineTo(firstX, firstY);
-        } else {
-          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, lastY);
-          context.lineTo(dimensions.width + seriesOptions.lineWidth + 1, dimensions.height + seriesOptions.lineWidth + 1);
-          context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth);
-        }
-        context.fillStyle = seriesOptions.fillStyle;
-        context.fill();
-      }
-
       if (seriesOptions.strokeStyle && seriesOptions.strokeStyle !== 'none') {
         context.lineWidth = seriesOptions.lineWidth;
         context.strokeStyle = seriesOptions.strokeStyle;
         context.stroke();
+      }
+
+      if (seriesOptions.fillStyle) {
+        // Close up the fill region.
+        context.lineTo(lastX, dimensions.height + seriesOptions.lineWidth + 1);
+        context.lineTo(firstX, dimensions.height + seriesOptions.lineWidth + 1);
+
+        context.fillStyle = seriesOptions.fillStyle;
+        context.fill();
       }
     }
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -1024,19 +1024,20 @@
     }
     this.updateTooltip();
 
+    var labelsOptions = chartOptions.labels;
     // Draw the axis values on the chart.
-    if (!chartOptions.labels.disabled && !isNaN(this.valueRange.min) && !isNaN(this.valueRange.max)) {
-      var maxValueString = chartOptions.yMaxFormatter(this.valueRange.max, chartOptions.labels.precision),
-          minValueString = chartOptions.yMinFormatter(this.valueRange.min, chartOptions.labels.precision),
+    if (!labelsOptions.disabled && !isNaN(this.valueRange.min) && !isNaN(this.valueRange.max)) {
+      var maxValueString = chartOptions.yMaxFormatter(this.valueRange.max, labelsOptions.precision),
+          minValueString = chartOptions.yMinFormatter(this.valueRange.min, labelsOptions.precision),
           maxLabelPos = chartOptions.scrollBackwards ? 0 : dimensions.width - context.measureText(maxValueString).width - 2,
           minLabelPos = chartOptions.scrollBackwards ? 0 : dimensions.width - context.measureText(minValueString).width - 2;
-      context.fillStyle = chartOptions.labels.fillStyle;
-      context.fillText(maxValueString, maxLabelPos, chartOptions.labels.fontSize);
+      context.fillStyle = labelsOptions.fillStyle;
+      context.fillText(maxValueString, maxLabelPos, labelsOptions.fontSize);
       context.fillText(minValueString, minLabelPos, dimensions.height - 2);
     }
 
     // Display intermediate y axis labels along y-axis to the left of the chart
-    if ( chartOptions.labels.showIntermediateLabels
+    if ( labelsOptions.showIntermediateLabels
           && !isNaN(this.valueRange.min) && !isNaN(this.valueRange.max)
           && chartOptions.grid.verticalSections > 0) {
       // show a label above every vertical section divider
@@ -1047,10 +1048,10 @@
         if (chartOptions.grid.sharpLines) {
           gy -= 0.5;
         }
-        var yValue = chartOptions.yIntermediateFormatter(this.valueRange.min + (v * step), chartOptions.labels.precision);
+        var yValue = chartOptions.yIntermediateFormatter(this.valueRange.min + (v * step), labelsOptions.precision);
         //left of right axis?
         intermediateLabelPos =
-          chartOptions.labels.intermediateLabelSameAxis
+          labelsOptions.intermediateLabelSameAxis
           ? (chartOptions.scrollBackwards ? 0 : dimensions.width - context.measureText(yValue).width - 2)
           : (chartOptions.scrollBackwards ? dimensions.width - context.measureText(yValue).width - 2 : 0);
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -97,6 +97,7 @@
  *        Allow setting interpolation per time series, by @WofWca (#123)
  *        Fix a memory leak appearing when some `timeSeries.disabled === true`, by @WofWca (#132)
  *        Improve performance, by @WofWca (#135)
+ *        Fix series fill & stroke being inconsistent for last data time < render time, by @WofWca (#138)
  */
 
 ;(function(exports) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -910,17 +910,17 @@
 
     // For each data set...
     for (var d = 0; d < this.seriesSet.length; d++) {
-      context.save();
       var timeSeries = this.seriesSet[d].timeSeries;
-      if (timeSeries.disabled) {
-          continue;
-      }
-
-      var dataSet = timeSeries.data,
-          seriesOptions = this.seriesSet[d].options;
 
       // Delete old data that's moved off the left of the chart.
       timeSeries.dropOldData(oldestValidTime, chartOptions.maxDataSetLength);
+      if (timeSeries.disabled) {
+          continue;
+      }
+      context.save();
+
+      var dataSet = timeSeries.data,
+          seriesOptions = this.seriesSet[d].options;
 
       // Set style for this dataSet.
       context.lineWidth = seriesOptions.lineWidth;

--- a/smoothie.js
+++ b/smoothie.js
@@ -95,6 +95,7 @@
  *        Add title option, by @mesca
  *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  *        Allow setting interpolation per time series, by @WofWca (#123)
+ *        Fix a memory leak appearing when some `timeSeries.disabled === true`, by @WofWca (#132)
  */
 
 ;(function(exports) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -1018,7 +1018,6 @@
         context.strokeStyle = seriesOptions.strokeStyle;
         context.stroke();
       }
-      context.closePath();
     }
 
     if (chartOptions.tooltip && this.mouseX >= 0) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -215,30 +215,42 @@
 	if (isNaN(timestamp) || isNaN(value)){
 		return
 	}  
-    // Rewind until we hit an older timestamp
-    var i = this.data.length - 1;
-    while (i >= 0 && this.data[i][0] > timestamp) {
-      i--;
-    }
 
-    if (i === -1) {
-      // This new item is the oldest data
-      this.data.splice(0, 0, [timestamp, value]);
-    } else if (this.data.length > 0 && this.data[i][0] === timestamp) {
-      // Update existing values in the array
-      if (sumRepeatedTimeStampValues) {
-        // Sum this value into the existing 'bucket'
-        this.data[i][1] += value;
-        value = this.data[i][1];
-      } else {
-        // Replace the previous value
-        this.data[i][1] = value;
+    var lastI = this.data.length - 1;
+    if (lastI >= 0) {
+      // Rewind until we find the place for the new data
+      var i = lastI;
+      while (true) {
+        var iThData = this.data[i];
+        if (timestamp >= iThData[0]) {
+          if (timestamp === iThData[0]) {
+            // Update existing values in the array
+            if (sumRepeatedTimeStampValues) {
+              // Sum this value into the existing 'bucket'
+              iThData[1] += value;
+              value = iThData[1];
+            } else {
+              // Replace the previous value
+              iThData[1] = value;
+            }
+          } else {
+            // Splice into the correct position to keep timestamps in order
+            this.data.splice(i + 1, 0, [timestamp, value]);
+          }
+
+          break;
+        }
+
+        i--;
+        if (i < 0) {
+          // This new item is the oldest data
+          this.data.splice(0, 0, [timestamp, value]);
+
+          break;
+        }
       }
-    } else if (i < this.data.length - 1) {
-      // Splice into the correct position to keep timestamps in order
-      this.data.splice(i + 1, 0, [timestamp, value]);
     } else {
-      // Add to the end of the array
+      // It's the first element
       this.data.push([timestamp, value]);
     }
 

--- a/smoothie.js
+++ b/smoothie.js
@@ -935,9 +935,6 @@
 
       var seriesOptions = this.seriesSet[d].options;
 
-      // Set style for this dataSet.
-      context.lineWidth = seriesOptions.lineWidth;
-      context.strokeStyle = seriesOptions.strokeStyle;
       // Draw the line...
       context.beginPath();
       // Retain lastX, lastY for calculating the control points of bezier curves.
@@ -1005,6 +1002,8 @@
       }
 
       if (seriesOptions.strokeStyle && seriesOptions.strokeStyle !== 'none') {
+        context.lineWidth = seriesOptions.lineWidth;
+        context.strokeStyle = seriesOptions.strokeStyle;
         context.stroke();
       }
       context.closePath();

--- a/smoothie.js
+++ b/smoothie.js
@@ -96,6 +96,7 @@
  *        Fix data drop stoppage by rejecting NaNs in append(), by @timdrysdale
  *        Allow setting interpolation per time series, by @WofWca (#123)
  *        Fix a memory leak appearing when some `timeSeries.disabled === true`, by @WofWca (#132)
+ *        Improve performance, by @WofWca (#135)
  */
 
 ;(function(exports) {

--- a/smoothie.js
+++ b/smoothie.js
@@ -844,10 +844,6 @@
 
     context.font = chartOptions.labels.fontSize + 'px ' + chartOptions.labels.fontFamily;
 
-    // Save the state of the canvas context, any transformations applied in this method
-    // will get removed from the stack at the end of this method when .restore() is called.
-    context.save();
-
     // Move the origin.
     context.translate(dimensions.left, dimensions.top);
 
@@ -859,14 +855,11 @@
     context.clip();
 
     // Clear the working area.
-    context.save();
     context.fillStyle = chartOptions.grid.fillStyle;
     context.clearRect(0, 0, dimensions.width, dimensions.height);
     context.fillRect(0, 0, dimensions.width, dimensions.height);
-    context.restore();
 
     // Grid lines...
-    context.save();
     context.lineWidth = chartOptions.grid.lineWidth;
     context.strokeStyle = chartOptions.grid.strokeStyle;
     // Vertical (time) dividers.
@@ -904,7 +897,6 @@
       context.strokeRect(0, 0, dimensions.width, dimensions.height);
       context.closePath();
     }
-    context.restore();
 
     // Draw any horizontal lines...
     if (chartOptions.horizontalLines && chartOptions.horizontalLines.length) {
@@ -931,7 +923,6 @@
       if (dataSet.length <= 1 || timeSeries.disabled) {
           continue;
       }
-      context.save();
 
       var seriesOptions = this.seriesSet[d].options;
 
@@ -1007,8 +998,6 @@
         context.stroke();
       }
       context.closePath();
-
-      context.restore();
     }
 
     if (chartOptions.tooltip && this.mouseX >= 0) {
@@ -1106,8 +1095,6 @@
       context.fillStyle = chartOptions.title.fillStyle;
       context.fillText(chartOptions.title.text, titleXPos, titleYPos);
     }
-
-    context.restore(); // See .save() above.
   };
 
   // Sample timestamp formatting function

--- a/smoothie.js
+++ b/smoothie.js
@@ -929,49 +929,47 @@
       // Draw the line...
       context.beginPath();
       // Retain lastX, lastY for calculating the control points of bezier curves.
-      var firstX = 0, firstY = 0, lastX = 0, lastY = 0;
-      for (var i = 0; i < dataSet.length; i++) {
+      var firstX = timeToXPixel(dataSet[0][0]),
+        firstY = valueToYPixel(dataSet[0][1]),
+        lastX = firstX,
+        lastY = firstY;
+      context.moveTo(firstX, firstY);
+      for (var i = 1; i < dataSet.length; i++) {
         var x = timeToXPixel(dataSet[i][0]),
             y = valueToYPixel(dataSet[i][1]);
 
-        if (i === 0) {
-          firstX = x;
-          firstY = y;
-          context.moveTo(x, y);
-        } else {
-          switch (seriesOptions.interpolation || chartOptions.interpolation) {
-            case "linear":
-            case "line": {
-              context.lineTo(x,y);
-              break;
-            }
-            case "bezier":
-            default: {
-              // Great explanation of Bezier curves: http://en.wikipedia.org/wiki/Bezier_curve#Quadratic_curves
-              //
-              // Assuming A was the last point in the line plotted and B is the new point,
-              // we draw a curve with control points P and Q as below.
-              //
-              // A---P
-              //     |
-              //     |
-              //     |
-              //     Q---B
-              //
-              // Importantly, A and P are at the same y coordinate, as are B and Q. This is
-              // so adjacent curves appear to flow as one.
-              //
-              context.bezierCurveTo( // startPoint (A) is implicit from last iteration of loop
-                Math.round((lastX + x) / 2), lastY, // controlPoint1 (P)
-                Math.round((lastX + x)) / 2, y, // controlPoint2 (Q)
-                x, y); // endPoint (B)
-              break;
-            }
-            case "step": {
-              context.lineTo(x,lastY);
-              context.lineTo(x,y);
-              break;
-            }
+        switch (seriesOptions.interpolation || chartOptions.interpolation) {
+          case "linear":
+          case "line": {
+            context.lineTo(x,y);
+            break;
+          }
+          case "bezier":
+          default: {
+            // Great explanation of Bezier curves: http://en.wikipedia.org/wiki/Bezier_curve#Quadratic_curves
+            //
+            // Assuming A was the last point in the line plotted and B is the new point,
+            // we draw a curve with control points P and Q as below.
+            //
+            // A---P
+            //     |
+            //     |
+            //     |
+            //     Q---B
+            //
+            // Importantly, A and P are at the same y coordinate, as are B and Q. This is
+            // so adjacent curves appear to flow as one.
+            //
+            context.bezierCurveTo( // startPoint (A) is implicit from last iteration of loop
+              Math.round((lastX + x) / 2), lastY, // controlPoint1 (P)
+              Math.round((lastX + x)) / 2, y, // controlPoint2 (Q)
+              x, y); // endPoint (B)
+            break;
+          }
+          case "step": {
+            context.lineTo(x,lastY);
+            context.lineTo(x,y);
+            break;
           }
         }
 


### PR DESCRIPTION
It would depend on `scrollBackwards` and `fillStyle` being `undefined` or not. Depending on this, it would either continue the line up to the edge of the canvas or leave it at `lastX`. This makes it so that it is always left at `lastX`.

#### An example
Before:
![](https://user-images.githubusercontent.com/39462442/136520943-87d43f1b-2036-42c1-8859-fc3db54e8096.png)

After:
![](https://user-images.githubusercontent.com/39462442/136521262-39468151-5a1a-4f6c-8b47-601725cd43e2.png)

TODO:
* [ ] Merge #135 or rebase.