### PR TITLE
perf: remove unnecessary `context.save()`& `context.restore()`

### DIFF
--- a/smoothie.js
+++ b/smoothie.js
@@ -872,10 +872,6 @@
 
     context.font = chartOptions.labels.fontSize + 'px ' + chartOptions.labels.fontFamily;
 
-    // Save the state of the canvas context, any transformations applied in this method
-    // will get removed from the stack at the end of this method when .restore() is called.
-    context.save();
-
     // Move the origin.
     context.translate(dimensions.left, dimensions.top);
 
@@ -887,14 +883,11 @@
     context.clip();
 
     // Clear the working area.
-    context.save();
     context.fillStyle = chartOptions.grid.fillStyle;
     context.clearRect(0, 0, dimensions.width, dimensions.height);
     context.fillRect(0, 0, dimensions.width, dimensions.height);
-    context.restore();
 
     // Grid lines...
-    context.save();
     context.lineWidth = chartOptions.grid.lineWidth;
     context.strokeStyle = chartOptions.grid.strokeStyle;
     // Vertical (time) dividers.
@@ -926,7 +919,6 @@
       context.strokeRect(0, 0, dimensions.width, dimensions.height);
       context.closePath();
     }
-    context.restore();
 
     // Draw any horizontal lines...
     if (chartOptions.horizontalLines && chartOptions.horizontalLines.length) {
@@ -954,7 +946,6 @@
       if (dataSet.length <= 1 || timeSeries.disabled) {
           continue;
       }
-      context.save();
 
       var seriesOptions = this.seriesSet[d].options,
           // Keep in mind that `context.lineWidth = 0` doesn't actually set it to `0`.
@@ -1033,8 +1024,6 @@
         context.fillStyle = seriesOptions.fillStyle;
         context.fill();
       }
-
-      context.restore();
     }
 
     if (chartOptions.tooltip && this.mouseX >= 0) {
@@ -1129,8 +1118,6 @@
       context.fillStyle = chartOptions.title.fillStyle;
       context.fillText(chartOptions.title.text, titleXPos, titleYPos);
     }
-
-    context.restore(); // See .save() above.
   };
 
   // Sample timestamp formatting function


### PR DESCRIPTION
This reverts commit 3777c46dad9dcb1ed99a82d2ac2773547cb207c0.

Accidentally closed #141, this is the replacement. Sorry.

TODO:
* [ ] See the mentioned commit (3777c46dad9dcb1ed99a82d2ac2773547cb207c0), investigate, maybe file a bug in Chromium.
* [ ] If it was a Chromium bug, consider whether we should refrain from merging this in order to support older versions of Chromium (I think probably not).